### PR TITLE
add environment.yml for anaconda python distribution

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,35 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.6
+  - numpy
+  - scipy
+  - pyparsing
+  - networkx
+  - dill
+  - pyyaml
+  - lxml
+  - locket
+  - pdfrw
+  - psutil
+  - h5py
+  - wrapt
+  - sympy
+  - ply
+  - qscintilla2
+  - psycopg2
+  - pyvisa
+  - sqlalchemy
+  - sqlalchemy-utils
+  - plotly
+  - pip
+  - git
+  - pip:
+    - influxdb
+    - grpcio-tools
+    - https://gitlab.com/pmaunz/pyGSTi/uploads/f9d6b16f60fa3ef3033607afcf2a9da9/pyGSTi-0.9.4.4-cp36-cp36m-win_amd64.whl
+    - "-e git+https://gitlab.com/pmaunz/pint#egg=pint"
+    - "-e git+https://gitlab.com/pmaunz/pyqtgraph@develop-pm#egg=pyqtgraph"
+    - "-e git+https://gitlab.com/pmaunz/leastsqbound-scipy#egg=leastsqbound"
+    - "-e git+https://gitlab.com/pmaunz/objecthash#egg=objecthash"


### PR DESCRIPTION
I create an environment file for Anaconda python distribution. One can create an environment and install all the dependencies except Opal Kelly front panel API with the following commands. I believe it will be helpful for Anaconda users.

```
conda create --name IonControl
activate IonControl
conda env update
```